### PR TITLE
🩹 get reference list working

### DIFF
--- a/config/nameserver.php
+++ b/config/nameserver.php
@@ -2,14 +2,15 @@
 	// REFERENCE DNS //
 	$§DNSWATCH_NAMESERVER_REFERENCE["cloudflare"] = ["name" => "Cloudflare", "address" => ["1.1.1.1", "1.0.0.1"]];
 	$§DNSWATCH_NAMESERVER_REFERENCE["google"] = ["name" => "Google", "address" => ["8.8.8.8", "8.8.4.4"]];
-	$§DNSWATCH_NAMESERVER_REFERENCE["digitalcourage"] = ["name" => "digitalcourage", "address" => ["dns2.digitalcourage.de"]];
-	$§DNSWATCH_NAMESERVER_REFERENCE["ccc_berlin"] = ["name" => "CCC Berlin", "address" => ["dnscache.berlin.ccc.de"]];
-	$§DNSWATCH_NAMESERVER_REFERENCE["uncensoreddns"] = ["name" => "UncensoredDNS", "address" => ["unicast.censurfridns.dk"]];
+	#$§DNSWATCH_NAMESERVER_REFERENCE["digitalcourage"] = ["name" => "digitalcourage", "address" => ["dns2.digitalcourage.de"]];
+	#$§DNSWATCH_NAMESERVER_REFERENCE["ccc_berlin"] = ["name" => "CCC Berlin", "address" => ["dnscache.berlin.ccc.de"]];
+	#$§DNSWATCH_NAMESERVER_REFERENCE["uncensoreddns"] = ["name" => "UncensoredDNS", "address" => ["unicast.censurfridns.dk"]];
+	$§DNSWATCH_NAMESERVER_REFERENCE["quad9"] = ["name" => "Quad9", "address" => ["9.9.9.9", "149.112.112.112"]];
 	
 	
 	// CHECK DNS //
 	$§DNSWATCH_NAMESERVER["telekom_de"] = ["name" => "Telekom DE", "address" => ["dns.telekom.de"]];
 	$§DNSWATCH_NAMESERVER["vodafone_de"] = ["name" => "Vodafone DE", "address" => ["dns1.vodafone-ip.de", "dns2.vodafone-ip.de"]];
 	$§DNSWATCH_NAMESERVER["netaachen"] = ["name" => "Netaachen", "address" => ["na-dns-p01.netaachen.com"]];
-	$§DNSWATCH_NAMESERVER["quad9"] = ["name" => "Quad9", "address" => ["9.9.9.9", "149.112.112.112"]];
+	#$§DNSWATCH_NAMESERVER["quad9"] = ["name" => "Quad9", "address" => ["9.9.9.9", "149.112.112.112"]];
 ?>


### PR DESCRIPTION
`digitalcourage`, `ccc_berlin` and `uncensoreddns` don't work anymore